### PR TITLE
Fix srfi-128 for CHICKEN 5.0.2 and later

### DIFF
--- a/srfi-128.egg
+++ b/srfi-128.egg
@@ -13,4 +13,4 @@
   (extension
    srfi-128
    (types-file)
-   (csc-options "-O3" "-d2"))))
+   (csc-options "-keyword-style" "none" "-O3" "-d2"))))


### PR DESCRIPTION
See [this Salmonella output](https://salmonella-freebsd-x86-64.call-cc.org/master/clang/freebsd/x86-64/2019/05/05/salmonella-report/install/srfi-128.html)

In older CHICKENs, keywords could be bound like regular symbols, which
was a bit of a strange behaviour.  In 5.0.2 and later this no longer
works, so we'll need to either quote the symbols using pipe characters
or disable the keyword style reader.  The latter is best for portable
code as it requires no actual changes to be made to the upstream code.

So the patch simply disables keyword style, so that identifiers like `:comparator:` are accepted